### PR TITLE
Add reddit_my_saved_post and reddit_my_saved_comment tables

### DIFF
--- a/docs/tables/reddit_my_saved_comment.md
+++ b/docs/tables/reddit_my_saved_comment.md
@@ -1,0 +1,66 @@
+# Table: reddit_my_saved_comment
+
+Query your own saved comments.
+
+Note:
+When querying the `reddit_my_saved_post` or `reddit_my_saved_comment` tables, be aware that the underlying library fetches both saved posts and comments together from the Reddit API, with a default request of 100 items. Each query, however, will only return one type of item—either posts or comments—based on the table you are querying. Due to this behavior, the number of items returned in your query might be less than the total number of saved items you have, or the default request amount of 100, especially if there is a significant mix of saved posts and comments. The SQL `LIMIT` clause will only apply to the data returned by the library, not the data requested from the Reddit API.
+
+## Examples
+
+### 5 most recent comments
+
+```sql
+select
+  created_utc,
+  permalink,
+  body
+from
+  reddit_my_saved_comment
+order by
+  created_utc desc
+limit 5;
+```
+
+### Top 5 comments by score
+
+```sql
+select
+  score,
+  permalink,
+  body,
+  replies
+from
+  reddit_my_saved_comment
+order by
+  score desc
+limit 5;
+```
+
+### Comments by subreddit
+
+```sql
+select
+  subreddit_name_prefixed,
+  count(*)
+from
+  reddit_my_saved_comment
+group by
+  subreddit_name_prefixed
+order by
+  count desc;
+```
+
+### Comments containing the word "docs"
+
+```sql
+select
+  created_utc,
+  permalink,
+  body
+from
+  reddit_my_saved_comment
+where
+  body ilike '%docs%'
+order by
+  created_utc;
+```

--- a/docs/tables/reddit_my_saved_post.md
+++ b/docs/tables/reddit_my_saved_post.md
@@ -1,0 +1,67 @@
+# Table: reddit_my_saved_post
+
+Query your saved posts.
+
+Note:
+When querying the `reddit_my_saved_post` or `reddit_my_saved_comment` tables, be aware that the underlying library fetches both saved posts and comments together from the Reddit API, with a default request of 100 items. Each query, however, will only return one type of item—either posts or comments—based on the table you are querying. Due to this behavior, the number of items returned in your query might be less than the total number of saved items you have, or the default request amount of 100, especially if there is a significant mix of saved posts and comments. The SQL `LIMIT` clause will only apply to the data returned by the library, not the data requested from the Reddit API.
+
+## Examples
+
+### 5 most recent posts
+
+```sql
+select
+  created_utc,
+  title,
+  url
+from
+  reddit_my_saved_post
+order by
+  created_utc desc
+limit 5;
+```
+
+### Top 5 posts by score
+
+```sql
+select
+  score,
+  upvote_ratio,
+  title,
+  url
+from
+  reddit_my_saved_post
+order by
+  score desc
+limit 5;
+```
+
+### Posts by subreddit
+
+```sql
+select
+  subreddit_name_prefixed,
+  count(*)
+from
+  reddit_my_saved_post
+group by
+  subreddit_name_prefixed
+order by
+  count desc;
+```
+
+### Posts containing the word "docs"
+
+```sql
+select
+  created_utc,
+  title,
+  url,
+  selftext
+from
+  reddit_my_saved_post
+where
+  selftext ilike '%docs%'
+order by
+  created_utc;
+```

--- a/reddit/plugin.go
+++ b/reddit/plugin.go
@@ -24,6 +24,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"reddit_my_friend":               tableRedditMyFriend(ctx),
 			"reddit_my_info":                 tableRedditMyInfo(ctx),
 			"reddit_my_post":                 tableRedditMyPost(ctx),
+			"reddit_my_saved_post":           tableRedditMySavedPost(ctx),
+			"reddit_my_saved_comment":        tableRedditMySavedComment(ctx),
 			"reddit_my_subscribed_subreddit": tableRedditMySubscribedSubreddit(ctx),
 			"reddit_my_moderated_subreddit":  tableRedditMyModeratedSubreddit(ctx),
 			"reddit_popular_subreddit":       tableRedditPopularSubreddit(ctx),

--- a/reddit/table_reddit_my_saved_comment.go
+++ b/reddit/table_reddit_my_saved_comment.go
@@ -1,0 +1,113 @@
+package reddit
+
+import (
+	"context"
+
+	"github.com/vartanbeno/go-reddit/v2/reddit"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableRedditMySavedComment(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "reddit_my_saved_comment",
+		Description: "Your saved comments.",
+		List: &plugin.ListConfig{
+			Hydrate: listMySavedComment,
+		},
+		Columns: []*plugin.Column{
+			// Top columns
+			{Name: "rank", Type: proto.ColumnType_INT, Description: "Rank of the comment among the result rows, use for sorting."},
+			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.ID"), Description: "ID of the comment."},
+			{Name: "name", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.FullID"), Description: "Slug (full ID) of the comment."},
+			{Name: "created_utc", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Comment.Created").Transform(timeToRfc3339), Description: "Time when the comment was created."},
+			{Name: "edited", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Comment.Edited").Transform(timeToRfc3339), Description: "Time when the comment was edited."},
+			{Name: "parent_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.ParentID"), Description: "Permalink (path only) to the comment."},
+			{Name: "permalink", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.Permalink"), Description: "Permalink (path only) to the comment."},
+			{Name: "body", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.Body"), Description: "Body of the comment."},
+			{Name: "author", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.Author"), Description: "Author of the comment."},
+			{Name: "author_fullname", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.AuthorID"), Description: "Full name of the author for the comment."},
+			{Name: "author_flair_text", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.AuthorFlairText"), Description: "Flair text of the author for the comment."},
+			{Name: "author_flair_template_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.AuthorFlairID"), Description: "ID of the flair template of the author for the comment."},
+			{Name: "subreddit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.SubredditName"), Description: "Name of the subreddit, e.g. aws."},
+			{Name: "subreddit_name_prefixed", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.SubredditNamePrefixed"), Description: "Prefixed name of the subreddit, e.g. /r/aws."},
+			{Name: "subreddit_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.SubredditID"), Description: "ID of the subreddit."},
+			{Name: "likes", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.Likes"), Description: "True if you've upvoted the comment. False if you've downvoted it. Otherwise null."},
+			{Name: "score", Type: proto.ColumnType_INT, Transform: transform.FromField("Comment.Score"), Description: "Score of the comment."},
+			{Name: "controversiality", Type: proto.ColumnType_INT, Transform: transform.FromField("Comment.Controversiality"), Description: "Controversiality score of the comment."},
+			{Name: "link_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.PostID"), Description: ""},
+			{Name: "link_title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.PostTitle"), Description: ""},
+			{Name: "link_permalink", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.PostPermalink"), Description: ""},
+			{Name: "link_author", Type: proto.ColumnType_STRING, Transform: transform.FromField("Comment.PostAuthor"), Description: ""},
+			{Name: "num_comments", Type: proto.ColumnType_INT, Transform: transform.FromField("Comment.PostNumComments"), Description: ""},
+			{Name: "is_submitter", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.IsSubmitter"), Description: "True if the comment is a spoiler."},
+			{Name: "score_hidden", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.ScoreHidden"), Description: "True if the score is hidden on this comment."},
+			{Name: "saved", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.Saved"), Description: "True if the comment has been saved."},
+			{Name: "stickied", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.Stickied"), Description: "True if the comment has been stickied."},
+			{Name: "locked", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.Locked"), Description: "True if the comment is locked."},
+			{Name: "can_gild", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.CanGild"), Description: ""},
+			{Name: "over_18", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Comment.NSFW"), Description: "True if the comment is not safe for work (over 18)."},
+			{Name: "replies", Type: proto.ColumnType_JSON, Transform: transform.FromField("Comment.Replies.Comments"), Description: "Replies to the comment."},
+		},
+	}
+}
+
+type MySavedCommentRow struct {
+	Comment *reddit.Comment
+	// Return rank to sort results
+	Rank int `json:"rank"`
+}
+
+func listMySavedComment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	conn, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("reddit_my_comment.listMySavedComment", "connection_error", err)
+		return nil, err
+	}
+
+	authUserCached := plugin.HydrateFunc(getRedditAuthenticatedUser).WithCache()
+	commonData, _ := authUserCached(ctx, d, h)
+	authUser := commonData.(string)
+
+	if authUser != "" {
+		conn.Username = authUser
+	}
+
+	opts := &reddit.ListUserOverviewOptions{
+		ListOptions: reddit.ListOptions{
+			Limit: 100,
+		},
+		// One of: hot, new, top, controversial.
+		Sort: "top",
+		// One of: hour, day, week, month, year, all.
+		Time: "all",
+	}
+
+	count := 0
+	for {
+		_, items, resp, err := conn.User.Saved(ctx, opts)
+		if err != nil {
+			plugin.Logger(ctx).Error("reddit_my_comment.listMySavedComment", "query_error", err, "resp", resp, "opts", opts)
+			return nil, err
+		}
+		for _, i := range items {
+			count++
+			row := MySavedCommentRow{
+				i,
+				count,
+			}
+			d.StreamListItem(ctx, row)
+		}
+		// Stop if we've reached the end, or the max target limit
+		if resp.After == "" {
+			break
+		}
+		// Set the page and continue
+		opts.After = resp.After
+	}
+
+	return nil, nil
+}

--- a/reddit/table_reddit_my_saved_post.go
+++ b/reddit/table_reddit_my_saved_post.go
@@ -1,0 +1,107 @@
+package reddit
+
+import (
+	"context"
+
+	"github.com/vartanbeno/go-reddit/v2/reddit"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableRedditMySavedPost(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "reddit_my_saved_post",
+		Description: "Your saved posts.",
+		List: &plugin.ListConfig{
+			Hydrate: listMySavedPost,
+		},
+		Columns: []*plugin.Column{
+			// Top columns
+			{Name: "rank", Type: proto.ColumnType_INT, Description: "Rank of the post among the result rows, use for sorting."},
+			{Name: "id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.ID"), Description: "ID of the post."},
+			{Name: "name", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.FullID"), Description: "Slug (full ID) of the post."},
+			{Name: "created_utc", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Post.Created").Transform(timeToRfc3339), Description: "Time when the post was created."},
+			{Name: "edited", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Post.Edited").Transform(timeToRfc3339), Description: "Time when the post was edited."},
+			{Name: "permalink", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.Permalink"), Description: "Permalink (path only) to the post."},
+			{Name: "url", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.URL"), Description: "URL the post links to, or of the post itself."},
+			{Name: "title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.Title"), Description: "Title of the post."},
+			{Name: "selftext", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.Body"), Description: "Body of the post."},
+			{Name: "likes", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.Likes"), Description: "True if you've upvoted the post. False if you've downvoted it. Otherwise null."},
+			{Name: "score", Type: proto.ColumnType_INT, Transform: transform.FromField("Post.Score"), Description: "Score of the post."},
+			{Name: "upvote_ratio", Type: proto.ColumnType_DOUBLE, Transform: transform.FromField("Post.UpvoteRatio"), Description: "Upvote ratio of the post."},
+			{Name: "num_comments", Type: proto.ColumnType_INT, Transform: transform.FromField("Post.NumberOfComments"), Description: "Number of comments on the post."},
+			{Name: "subreddit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.SubredditName"), Description: "Name of the subreddit, e.g. aws."},
+			{Name: "subreddit_name_prefixed", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.SubredditNamePrefixed"), Description: "Prefixed name of the subreddit, e.g. /r/aws."},
+			{Name: "subreddit_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.SubredditID"), Description: "ID of the subreddit."},
+			{Name: "subreddit_subscribers", Type: proto.ColumnType_INT, Transform: transform.FromField("Post.SubredditSubscribers"), Description: "Number of subscribers to the subreddit."},
+			{Name: "author", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.Author"), Description: "Author of the post."},
+			{Name: "author_fullname", Type: proto.ColumnType_STRING, Transform: transform.FromField("Post.AuthorID"), Description: "Full name of the author for the post."},
+			{Name: "spoiler", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.Spoiler"), Description: "True if the post is a spoiler."},
+			{Name: "locked", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.Locked"), Description: "True if the post is locked."},
+			{Name: "over_18", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.NSFW"), Description: "True if the post is not safe for work (over 18)."},
+			{Name: "is_self", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.IsSelfPost"), Description: ""},
+			{Name: "saved", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.Saved"), Description: "True if the post has been saved."},
+			{Name: "stickied", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Post.Stickied"), Description: "True if the post has been stickied."},
+		},
+	}
+}
+
+type mySavedPostRow struct {
+	Post *reddit.Post
+	// Return rank to sort results
+	Rank int `json:"rank"`
+}
+
+func listMySavedPost(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	conn, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("reddit_my_saved_post.listMySavedPost", "connection_error", err)
+		return nil, err
+	}
+
+	authUserCached := plugin.HydrateFunc(getRedditAuthenticatedUser).WithCache()
+	commonData, _ := authUserCached(ctx, d, h)
+	authUser := commonData.(string)
+
+	if authUser != "" {
+		conn.Username = authUser
+	}
+
+	opts := &reddit.ListUserOverviewOptions{
+		ListOptions: reddit.ListOptions{
+			Limit: 100,
+		},
+		// One of: hot, new, top, controversial.
+		Sort: "top",
+		// One of: hour, day, week, month, year, all.
+		Time: "all",
+	}
+
+	count := 0
+	for {
+		items, _, resp, err := conn.User.Saved(ctx, opts)
+		if err != nil {
+			plugin.Logger(ctx).Error("reddit_my_post.listMySavedPost", "query_error", err, "resp", resp, "opts", opts)
+			return nil, err
+		}
+		for _, i := range items {
+			count++
+			row := mySavedPostRow{
+				i,
+				count,
+			}
+			d.StreamListItem(ctx, row)
+		}
+		// Stop if we've reached the end, or the max target limit
+		if resp.After == "" {
+			break
+		}
+		// Set the page and continue
+		opts.After = resp.After
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
There is a bit of a "gotcha" for users of the plugin in this PR.

`go-reddit`'s `*UserService.Saved()` method returns back both posts and comments that the user has saved.

```go
// Saved returns a list of the user's saved posts and comments.
func (s *UserService) Saved(ctx context.Context, opts *ListUserOverviewOptions) ([]*Post, []*Comment, *Response, error) {
    path := fmt.Sprintf("user/%s/saved", s.client.Username)
    l, resp, err := s.client.getListing(ctx, path, opts)
    if err != nil {
        return nil, nil, resp, err
    }
    return l.Posts(), l.Comments(), resp, nil
}
```

 And it doesn't appear that `*ListUserOverviewOptions` allows for filtering just by posts or comments, even though the Reddit API does (<https://www.reddit.com/dev/api#GET_user_{username}_saved>).

```go
// ListOptions specifies the optional parameters to various API calls that return a listing.
type ListOptions struct {
    // Maximum number of items to be returned.
    // Generally, the default is 25 and max is 100.
    Limit int `url:"limit,omitempty"`

    // The full ID of an item in the listing to use
    // as the anchor point of the list. Only items
    // appearing after it will be returned.
    After string `url:"after,omitempty"`

    // The full ID of an item in the listing to use
    // as the anchor point of the list. Only items
    // appearing before it will be returned.
    Before string `url:"before,omitempty"`
}

// ListUserOverviewOptions defines possible options used when getting a user's post and/or comments.
type ListUserOverviewOptions struct {
    ListOptions
    // One of: hot, new, top, controversial.
    Sort string `url:"sort,omitempty"`
    // One of: hour, day, week, month, year, all.
    Time string `url:"t,omitempty"`
}
```

Combining the types into a single table felt like an exercise in pulling out my hair for something that I'm just doing for fun. Instead, `listMySavedComment` and `listMySavedPost` both discard the unrequested type.

```go
// listMySavedPost
items, _, resp, err := conn.User.Saved(ctx, opts)

// listMySavedComment
_, items, resp, err := conn.User.Saved(ctx, opts)
```

However, this means that even if a user has 100 saved comments, and they use the default `Limit: 100`, but those saved comments are inbetween saved post records, there might be confusion about why they received fewer than 100 results back. I have added a note to the documentation pages for both tables, but am uncertain if they appropriately convey what's happening.

Because this is just for fun, if the response to this PR is that you would instead like some additional work done to make the requests for posts & comments separately, I'll probably just close it. (Not snark. Just not up for it. Just hoping to not have to maintain my own fork.)

## Example query results

<details>
  <summary><code>select * from reddit.reddit_my_saved_post where is_self = false limit 1;</code></summary>

```txt
+------+--------+-----------+---------------------------+--------+----------------------------------------------------------------------------------------+-----------------------------------------+---------------------------------------------------+----------+--------+-------+--------------+--------------+--------------------+-------------------------+--------------+-----------------------+----------+-----------------+---------+--------+---------+---------+-------+----------+------------------------------+
| rank | id     | name      | created_utc               | edited | permalink                                                                              | url                                     | title                                             | selftext | likes  | score | upvote_ratio | num_comments | subreddit          | subreddit_name_prefixed | subreddit_id | subreddit_subscribers | author   | author_fullname | spoiler | locked | over_18 | is_self | saved | stickied | _ctx                         |
+------+--------+-----------+---------------------------+--------+----------------------------------------------------------------------------------------+-----------------------------------------+---------------------------------------------------+----------+--------+-------+--------------+--------------+--------------------+-------------------------+--------------+-----------------------+----------+-----------------+---------+--------+---------+---------+-------+----------+------------------------------+
| 4    | lu091a | t3_lu091a | 2021-02-27T15:40:12-08:00 | <null> | /r/coolgithubprojects/comments/lu091a/eezy_super_simple_script_running_and_management/ | https://github.com/simonmeulenbeek/Eezy | Eezy - Super Simple Script Running and Management |          | <null> | 4     | 1            | 3            | coolgithubprojects | r/coolgithubprojects    | t5_31g1m     | 50251                 | legacynl | t2_7p14v        | false   | false  | false   | false   | true  | false    | {"connection_name":"reddit"} |
+------+--------+-----------+---------------------------+--------+----------------------------------------------------------------------------------------+-----------------------------------------+---------------------------------------------------+----------+--------+-------+--------------+--------------+--------------------+-------------------------+--------------+-----------------------+----------+-----------------+---------+--------+---------+---------+-------+----------+------------------------------+

```

</details>

<details>
  <summary><code>select * from reddit.reddit_my_saved_comment where parent_id = 't1_ipmlby4';</code></summary>

```txt
+------+---------+------------+---------------------------+--------+------------+---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----------------+-------------------+--------------------------+-----------+-------------------------+--------------+--------+-------+------------------+-----------+-----------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------+-------------+--------------+--------------+--------------+-------+----------+--------+----------+---------+---------+------------------------------+
| rank | id      | name       | created_utc               | edited | parent_id  | permalink                                                                             | body                                                                                                                                                                                                                         | author   | author_fullname | author_flair_text | author_flair_template_id | subreddit | subreddit_name_prefixed | subreddit_id | likes  | score | controversiality | link_id   | link_title                                                                              | link_permalink                                                                                      | link_author | num_comments | is_submitter | score_hidden | saved | stickied | locked | can_gild | over_18 | replies | _ctx                         |
+------+---------+------------+---------------------------+--------+------------+---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----------------+-------------------+--------------------------+-----------+-------------------------+--------------+--------+-------+------------------+-----------+-----------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------+-------------+--------------+--------------+--------------+-------+----------+--------+----------+---------+---------+------------------------------+
| 1    | ipmlqj2 | t1_ipmlqj2 | 2022-09-23T11:51:27-07:00 | <null> | t1_ipmlby4 | /r/sysadmin/comments/xm473l/if_battlestar_galactica_proved_anything_toasters/ipmlqj2/ | This is the way to go imo. Heck, even a raspberry pi would be more than enough to handle tens of devices. I'd rather sit down for a week and fiddle around than spend 300+ USD on a local system or buy cheap cloud devices. | 93tami29 | t2_3t5uc5l4     |                   |                          | sysadmin  | r/sysadmin              | t5_2qnp7     | <null> | 173   | 0                | t3_xm473l | If Battlestar Galactica proved anything, toasters shouldn't have access to your network | https://www.reddit.com/r/sysadmin/comments/xm473l/if_battlestar_galactica_proved_anything_toasters/ | huxley75    | 386          | false        | false        | true  | false    | false  | false    | false   | <null>  | {"connection_name":"reddit"} |
+------+---------+------------+---------------------------+--------+------------+---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----------------+-------------------+--------------------------+-----------+-------------------------+--------------+--------+-------+------------------+-----------+-----------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------+-------------+--------------+--------------+--------------+-------+----------+--------+----------+---------+---------+------------------------------+
```

</details>
